### PR TITLE
Fixed packet ACTION_SET_DATE on AmigaOS.

### DIFF
--- a/src/filesys.c
+++ b/src/filesys.c
@@ -3207,7 +3207,7 @@ action_set_date (Unit *unit, dpacket packet)
 
     a = find_aino (unit, lock, bstr (unit, name), &err);
 #if defined TARGET_AMIGAOS && defined WORDS_BIGENDIAN
-    if (err == 0 && SetFileDate (a->nname, (struct DateStamp *) date) == DOSFALSE)
+    if (err == 0 && SetFileDate (a->nname, (struct DateStamp *) get_real_address(date)) == DOSFALSE)
 	err = IoErr ();
 #else
     ut.actime = ut.modtime = put_time(get_long (date), get_long (date + 4),


### PR DESCRIPTION
Without the fix, copy clone or similar actions would result in a DSI.

Signed-off-by: Josef Wegner <josef.wegner@outlook.com>